### PR TITLE
[DP-313] Dont drop messages on rebalance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.pinterest</groupId>
     <artifactId>secor</artifactId>
-    <version>0.28-SNAPSHOT</version>
+    <version>0.27</version>
     <packaging>jar</packaging>
     <name>secor</name>
     <description>Kafka to s3/gs/swift logs exporter</description>

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -363,6 +363,10 @@ public class SecorConfig {
         return getString("secor.upload.manager.class");
     }
 
+    public String getInnerUploadManagerClass() {
+        return getString("secor.inner.upload.manager.class");
+    }
+
     public String getMessageTransformerClass(){
     	return getString("secor.message.transformer.class");
     }
@@ -570,6 +574,10 @@ public class SecorConfig {
 
     public String getFileReaderWriterFactory() {
     	return getString("secor.file.reader.writer.factory");
+    }
+
+    public String getDestinationFileReaderWriterFactory() {
+    	return getString("secor.file.destination.reader.writer.factory");
     }
 
     public String getFileReaderDelimiter(){

--- a/src/main/java/com/pinterest/secor/uploader/FormatConvertingUploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/FormatConvertingUploadManager.java
@@ -28,6 +28,7 @@ import com.pinterest.secor.util.IdUtil;
 import com.pinterest.secor.util.ReflectionUtil;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
 
@@ -53,25 +54,18 @@ public class FormatConvertingUploadManager extends UploadManager {
     @Override
     public TempFileUploadHandle<Handle<?>> upload(LogFilePath localPath) throws Exception {
         // convert the file from the internal format to the external format
-        System.out.println("localPath: " + localPath);
-        System.out.println("mUploadManager: " + mUploadManager);
         LogFilePath convertedFilePath = convertFile(localPath);
 
         // The TempFileUploadHandle will delete the temp file after it resolves
         return new TempFileUploadHandle(mUploadManager.upload(convertedFilePath), convertedFilePath);
     }
 
-    /**
-     * This method converts a file 
-     * Exposed for testing only
-     */
-    public LogFilePath convertFile(LogFilePath srcPath) throws Exception {
+    private LogFilePath convertFile(LogFilePath srcPath) throws Exception {
         FileReader reader = null;
         FileWriter writer = null;
         int copiedMessages = 0;
 
-        String localConvertedPrefix = mConfig.getLocalPath() + '/' +
-            IdUtil.getLocalMessageDir() + "/convertedForUpload";
+        String localConvertedPrefix = Paths.get(mConfig.getLocalPath(), IdUtil.getLocalMessageDir(), "convertedForUpload").toString();
         LogFilePath convertedFilePath = srcPath.withPrefix(localConvertedPrefix);
 
         try {
@@ -109,7 +103,7 @@ public class FormatConvertingUploadManager extends UploadManager {
     }
 
     /**
-     * This method is intended to be overwritten in tests.
+     * This method is intended to make mocking easier in tests.
      * @param srcPath source Path
      * @param codec compression codec
      * @return FileReader created file reader
@@ -125,7 +119,7 @@ public class FormatConvertingUploadManager extends UploadManager {
     }
 
     /**
-     * This method is intended to be overwritten in tests.
+     * This method is intended to make mocking easier in tests.
      * @param dstPath destination Path
      * @param codec compression codec
      * @return FileWriter created file writer
@@ -144,7 +138,7 @@ public class FormatConvertingUploadManager extends UploadManager {
     }
 
     /**
-     * This method is intended to be overwritten in tests.
+     * This method is intended to make mocking easier in tests.
      * @return UploadManager created upload manager
      * @throws Exception on error
      */

--- a/src/main/java/com/pinterest/secor/uploader/FormatConvertingUploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/FormatConvertingUploadManager.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.uploader.UploadManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.io.FileReader;
+import com.pinterest.secor.io.FileWriter;
+import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.util.CompressionUtil;
+import com.pinterest.secor.util.FileUtil;
+import com.pinterest.secor.util.ReflectionUtil;
+
+import org.apache.hadoop.io.compress.CompressionCodec;
+
+/**
+ * Manages uploads using the configured upload manager
+ * Converts the local files to the specified format before upload
+ *
+ * @author Jason Butterfield (jason.butterfield@outreach.io)
+ */
+public class FormatConvertingUploadManager extends UploadManager {
+    private static final Logger LOG = LoggerFactory.getLogger(FormatConvertingUploadManager.class);
+
+    private UploadManager mUploadManager;
+
+    public FormatConvertingUploadManager(SecorConfig config) throws Exception {
+        super(config);
+        mUploadManager = ReflectionUtil.createUploadManager(mConfig.getInnerUploadManagerClass(), mConfig);
+    }
+
+    @Override
+    public Handle<?> upload(LogFilePath localPath) throws Exception {
+        // convert the file from the internal format to the external format
+        LogFilePath convertedFilePath = localPath.withPrefix("convertedForUpload");
+
+        FileReader reader = null;
+        FileWriter writer = null;
+        int copiedMessages = 0;
+
+        try {
+            CompressionCodec codec = null;
+            String extension = "";
+            if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
+                codec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());
+                extension = codec.getDefaultExtension();
+            }
+
+            reader = createReader(localPath, codec);
+            writer = createWriter(convertedFilePath, codec);
+
+            KeyValue keyVal;
+            while ((keyVal = reader.next()) != null) {
+              writer.write(keyVal);
+              copiedMessages++;
+            }
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+            if (writer != null) {
+                writer.close();
+            }
+        }
+
+        LOG.info("converted {} messages from {} to {}",
+            copiedMessages,
+            localPath.getLogFilePath(),
+            convertedFilePath.getLogFilePath()
+        );
+
+        return new TempFileUploadHandle(mUploadManager.upload(convertedFilePath), convertedFilePath);
+    }
+
+    /**
+     * This method is intended to be overwritten in tests.
+     * @param srcPath source Path
+     * @param codec compression codec
+     * @return FileReader created file reader
+     * @throws Exception on error
+     */
+    protected FileReader createReader(LogFilePath srcPath, CompressionCodec codec) throws Exception {
+        return ReflectionUtil.createFileReader(
+          mConfig.getFileReaderWriterFactory(),
+          srcPath,
+          codec,
+          mConfig
+        );
+    }
+
+    protected FileWriter createWriter(LogFilePath dstPath, CompressionCodec codec) throws Exception {
+        FileWriter writer = ReflectionUtil.createFileWriter(
+          mConfig.getDestinationFileReaderWriterFactory(),
+          dstPath,
+          codec,
+          mConfig
+        );
+        FileUtil.deleteOnExit(dstPath.getLogFilePath());
+        FileUtil.deleteOnExit(dstPath.getLogFileCrcPath());
+        return writer;
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
+++ b/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.uploader.Handle;
+import com.pinterest.secor.util.FileUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Wraps an Upload being managed by the AWS SDK TransferManager. `get`
+ * blocks until the upload completes.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public class TempFileUploadHandle<T> implements Handle<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(TempFileUploadHandle.class);
+
+    private Handle<T> mHandle;
+    private LogFilePath mPath;
+
+    public TempFileUploadHandle(Handle<T> h, LogFilePath srcPath) {
+        mHandle = h;
+        mPath = srcPath;
+    }
+
+    public T get() throws Exception {
+        // wait for upload handle to complete, then delete the temp files
+        T result = mHandle.get();
+        FileUtil.delete(mPath.getLogFilePath());
+        FileUtil.delete(mPath.getLogFileCrcPath());
+        LOG.debug("deleting temp files {} and {}",
+            mPath.getLogFilePath(),
+            mPath.getLogFileCrcPath()
+        );
+        return result;
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
+++ b/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
@@ -25,10 +25,11 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Wraps an Upload being managed by the AWS SDK TransferManager. `get`
- * blocks until the upload completes.
+ * Wraps an Upload of a temp file
+ * Deletes the temp file after the
+ * wrapped Handle.get() resolves
  *
- * @author Liam Stewart (liam.stewart@gmail.com)
+ * @author Jason Butterfield (jason.butterfield@outreach.io)
  */
 public class TempFileUploadHandle<T> implements Handle<T> {
     private static final Logger LOG = LoggerFactory.getLogger(TempFileUploadHandle.class);
@@ -42,7 +43,6 @@ public class TempFileUploadHandle<T> implements Handle<T> {
     }
 
     public T get() throws Exception {
-        // wait for upload handle to complete, then delete the temp files
         T result = mHandle.get();
         FileUtil.delete(mPath.getLogFilePath());
         FileUtil.delete(mPath.getLogFileCrcPath());
@@ -51,5 +51,9 @@ public class TempFileUploadHandle<T> implements Handle<T> {
             mPath.getLogFileCrcPath()
         );
         return result;
+    }
+
+    public LogFilePath getTempFilePath() {
+      return mPath;
     }
 }

--- a/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
+++ b/src/main/java/com/pinterest/secor/uploader/TempFileUploadHandle.java
@@ -43,13 +43,18 @@ public class TempFileUploadHandle<T> implements Handle<T> {
     }
 
     public T get() throws Exception {
-        T result = mHandle.get();
-        FileUtil.delete(mPath.getLogFilePath());
-        FileUtil.delete(mPath.getLogFileCrcPath());
-        LOG.debug("deleting temp files {} and {}",
-            mPath.getLogFilePath(),
-            mPath.getLogFileCrcPath()
-        );
+        T result = null;
+        try {
+            result = mHandle.get();
+        } finally {
+            FileUtil.delete(mPath.getLogFilePath());
+            FileUtil.delete(mPath.getLogFileCrcPath());
+            LOG.debug("deleting temp files {} and {}",
+                mPath.getLogFilePath(),
+                mPath.getLogFileCrcPath()
+            );
+        }
+
         return result;
     }
 

--- a/src/test/java/com/pinterest/secor/uploader/FormatConvertingUploadManagerTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/FormatConvertingUploadManagerTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.google.common.io.Files;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.io.FileReader;
+import com.pinterest.secor.io.FileWriter;
+import com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFactory;
+import com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory;
+import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.uploader.FormatConvertingUploadManager;
+import com.pinterest.secor.uploader.S3UploadManager;
+import com.pinterest.secor.uploader.S3UploadHandle;
+import com.pinterest.secor.uploader.Handle;
+import com.pinterest.secor.uploader.TempFileUploadHandle;
+import com.pinterest.secor.uploader.TestHandle;
+import com.pinterest.secor.uploader.TestUploadManager;
+import com.pinterest.secor.uploader.UploadManager;
+import com.pinterest.secor.util.FileUtil;
+
+import java.io.IOException;
+import java.io.File;
+import java.util.HashSet;
+
+import junit.framework.TestCase;
+
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.joda.time.DateTime;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests logic of converting files from
+ * one format to another prior to upload
+ *
+ * @author Jason Butterfield (jason.butterfield@outreach.io)
+ */
+@RunWith(PowerMockRunner.class)
+public class FormatConvertingUploadManagerTest extends TestCase {
+
+    public void testUpload() throws Exception {
+        SecorConfig mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getFileReaderWriterFactory()).thenReturn("com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory");
+        Mockito.when(mConfig.getDestinationFileReaderWriterFactory()).thenReturn("com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFactory");
+        Mockito.when(mConfig.getInnerUploadManagerClass()).thenReturn("com.pinterest.secor.uploader.TestUploadManager");
+
+        FormatConvertingUploadManager unspiedUploadManager = new FormatConvertingUploadManager(mConfig);
+        FormatConvertingUploadManager uploadManager = Mockito.spy(unspiedUploadManager);
+
+        PowerMockito.whenNew(FormatConvertingUploadManager.class).withArguments(mConfig).thenReturn(uploadManager);
+
+        SequenceFileReaderWriterFactory sequenceFileFactory = new SequenceFileReaderWriterFactory();
+        LogFilePath tempLogFilePath = new LogFilePath(Files.createTempDir().toString(),
+                "test-topic",
+                new String[]{"part-1"},
+                0,
+                1,
+                23232,
+                ".log"
+        );
+
+        FileWriter writer = sequenceFileFactory.BuildFileWriter(tempLogFilePath, null);
+
+        KeyValue kv1 = new KeyValue(23232, "value1".getBytes());
+        KeyValue kv2 = new KeyValue(23233, "value2".getBytes());
+        writer.write(kv1);
+        writer.write(kv2);
+        writer.close();
+
+        TempFileUploadHandle<?> tempFileUploadHandle = uploadManager.upload(tempLogFilePath);
+        LogFilePath convertedFilePath = tempFileUploadHandle.getTempFilePath();
+
+        // test that the converted file contains the correct format
+        DelimitedTextFileReaderWriterFactory textFileFactory = new DelimitedTextFileReaderWriterFactory();
+        FileReader reader = textFileFactory.BuildFileReader(convertedFilePath, null);
+        KeyValue kvout = reader.next();
+        System.out.println("kvout.offset: " + kvout.getOffset() + " kvout.value: " + new String(kvout.getValue()));
+        System.out.println("kv1.offset: " + kv1.getOffset() + " kv1.value: " + new String(kv1.getValue()));
+        assertEquals(kv1.getOffset(), kvout.getOffset());
+        assertArrayEquals(kv1.getValue(), kvout.getValue());
+        
+        kvout = reader.next();
+        assertEquals(kv2.getOffset(), kvout.getOffset());
+        assertArrayEquals(kv2.getValue(), kvout.getValue());
+        reader.close();
+
+        // Test that it deletes the file after resolving the handle
+        tempFileUploadHandle.get();
+        assertEquals(false, (new File(convertedFilePath.getLogFilePath()).exists()));
+        assertEquals(false, (new File(convertedFilePath.getLogFileCrcPath()).exists()));
+    }
+}

--- a/src/test/java/com/pinterest/secor/uploader/FormatConvertingUploadManagerTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/FormatConvertingUploadManagerTest.java
@@ -99,8 +99,6 @@ public class FormatConvertingUploadManagerTest extends TestCase {
         DelimitedTextFileReaderWriterFactory textFileFactory = new DelimitedTextFileReaderWriterFactory();
         FileReader reader = textFileFactory.BuildFileReader(convertedFilePath, null);
         KeyValue kvout = reader.next();
-        System.out.println("kvout.offset: " + kvout.getOffset() + " kvout.value: " + new String(kvout.getValue()));
-        System.out.println("kv1.offset: " + kv1.getOffset() + " kv1.value: " + new String(kv1.getValue()));
         assertEquals(kv1.getOffset(), kvout.getOffset());
         assertArrayEquals(kv1.getValue(), kvout.getValue());
         

--- a/src/test/java/com/pinterest/secor/uploader/TestHandle.java
+++ b/src/test/java/com/pinterest/secor/uploader/TestHandle.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.uploader.Handle;
+
+/**
+ * Used in tests only
+ */
+public class TestHandle implements Handle<String> {
+
+    public TestHandle() {
+    }
+
+    @Override
+    public String get() throws Exception {
+        return "";
+    }
+}

--- a/src/test/java/com/pinterest/secor/uploader/TestUploadManager.java
+++ b/src/test/java/com/pinterest/secor/uploader/TestUploadManager.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.LogFilePath;
+
+import com.pinterest.secor.uploader.TestHandle;
+import com.pinterest.secor.uploader.UploadManager;
+
+/**
+ * Used in tests only
+ */
+public class TestUploadManager extends UploadManager {
+
+    public TestUploadManager(SecorConfig config) {
+      super(config);
+    };
+
+    @Override
+    public Handle<?> upload(LogFilePath localPath) throws Exception {
+      return new TestHandle();
+    }
+}


### PR DESCRIPTION
Secor has a bug when using file formats other than sequence files.  See https://github.com/pinterest/secor/issues/395 for more context, and the explanation below.

When secor sees that a consumer rebalance has happened, but the previous consumer was in the middle of uploading files and committed a new offset after the new consumer has started consuming, it attempts to trim messages out of its buffer files before uploading, to eliminate duplicates.  
Since offsets are not stored with the messages in those other formats, when it tries to trim existing files to remove offsets that have already been committed, it deletes messages that it should not have.

This PR fixes that by storing everything in sequence files locally, only converting to delimited text immediately before uploading the file.